### PR TITLE
Web debug container

### DIFF
--- a/0099FF-stack/web-debug/Dockerfile
+++ b/0099FF-stack/web-debug/Dockerfile
@@ -9,9 +9,9 @@
 # Notes
 # - django ssl server: https://github.com/teddziuba/django-sslserver
 # - to start the ssl server: "python manage.py runsslserver 0.0.0.0:8000"
-# - set the django site_base_url to "0.0.0.0:8000"
-# - responding on any ip address is needed because localhost means something different to the host, host vm (if any), 
-#   within each container.
+#   responding on any ip address is needed because localhost means something different to the host, 
+#   host vm (if any), and within each container. 
+# - set the django site_base_url to "127.0.0.0:8000"
 #
 # Copyright 2014 - 2016 devops.center
 #

--- a/0099FF-stack/web-debug/Dockerfile
+++ b/0099FF-stack/web-debug/Dockerfile
@@ -22,7 +22,8 @@ MAINTAINER bob < bob [at] devops {dot} center>
 # Setup config to run pgpool in this container
 # (requires supervisor)
 RUN rm -rf /etc/supervisor/conf.d/nginx.conf && \
-    rm -rf /etc/supervisor/conf.d/uwsgi.conf
+    rm -rf /etc/supervisor/conf.d/uwsgi.conf && \
+    export IS_DC_WEB_DEBUG=1
 
 # Run supervisor in this container, in foreground mode. However first establish link for logging container,
 # then remove stale PIDs which prevented pgpool from successfully running from a container that is restarted.

--- a/0099FF-stack/web-debug/Dockerfile
+++ b/0099FF-stack/web-debug/Dockerfile
@@ -1,0 +1,37 @@
+#
+# Docker Stack - Docker stack to manage infrastructures
+#
+# Copyright 2014 devops.center
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM devopscenter/0099ff.web:devops_version
+MAINTAINER bob < bob [at] devops {dot} center>
+
+# Setup config to run pgpool in this container
+# (requires supervisor)
+RUN rm -rf /etc/supervisor/conf.d/nginx.conf && \
+    rm -rf /etc/supervisor/conf.d/uwsgi.conf
+
+# Run supervisor in this container, in foreground mode. However first establish link for logging container,
+# then remove stale PIDs which prevented pgpool from successfully running from a container that is restarted.
+
+CMD ln -sf /var/run/rsyslog/dev/log /dev/log && \
+    rm -rf /var/run/pgpool/.s.* && \
+    rm -rf /tmp/.s.* && \
+    rm -rf /var/run/pgpool/pgpool.pid && \
+    rm -rf /var/run/postgresql/.s.* && \
+    supervisord -n
+
+

--- a/0099FF-stack/web-debug/Dockerfile
+++ b/0099FF-stack/web-debug/Dockerfile
@@ -19,11 +19,12 @@
 FROM devopscenter/0099ff.web:devops_version
 MAINTAINER bob < bob [at] devops {dot} center>
 
+ENV IS_DC_WEB_DEBUG=1
+
 # Setup config to run pgpool in this container
 # (requires supervisor)
 RUN rm -rf /etc/supervisor/conf.d/nginx.conf && \
-    rm -rf /etc/supervisor/conf.d/uwsgi.conf && \
-    export IS_DC_WEB_DEBUG=1
+    rm -rf /etc/supervisor/conf.d/uwsgi.conf
 
 # Run supervisor in this container, in foreground mode. However first establish link for logging container,
 # then remove stale PIDs which prevented pgpool from successfully running from a container that is restarted.

--- a/0099FF-stack/web-debug/Dockerfile
+++ b/0099FF-stack/web-debug/Dockerfile
@@ -21,7 +21,7 @@
 # limitations under the License.
 #
 
-FROM devopscenter/0099ff.web:v2.0b1
+FROM devopscenter/0099ff.web:devops_version
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ENV IS_DC_WEB_DEBUG=1

--- a/0099FF-stack/web-debug/Dockerfile
+++ b/0099FF-stack/web-debug/Dockerfile
@@ -1,7 +1,12 @@
 #
 # Docker Stack - Docker stack to manage infrastructures
 #
-# Copyright 2014 devops.center
+# WEB-DEBUG Container
+#   This container is designed to provide an interactive debugging environment for the first step in a dev
+#   workflow. Provides a connection to the db (via pgpool), and an additional ENV var (IS_DC_WEB_DEBUG) to
+#   permit settings.py to install the django sslserver, etc for interactive dev.
+#
+# Copyright 2014 - 2016 devops.center
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +21,7 @@
 # limitations under the License.
 #
 
-FROM devopscenter/0099ff.web:devops_version
+FROM devopscenter/0099ff.web:v2.0b1
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ENV IS_DC_WEB_DEBUG=1

--- a/0099FF-stack/web-debug/Dockerfile
+++ b/0099FF-stack/web-debug/Dockerfile
@@ -29,7 +29,10 @@ ENV IS_DC_WEB_DEBUG=1
 # Setup config to run pgpool in this container
 # (requires supervisor)
 RUN rm -rf /etc/supervisor/conf.d/nginx.conf && \
-    rm -rf /etc/supervisor/conf.d/uwsgi.conf
+    rm -rf /etc/supervisor/conf.d/uwsgi.conf && \
+
+# Install django ssl-server for local, interactive debugging while serving the site
+    pip install django-sslserver
 
 # Run supervisor in this container, in foreground mode. However first establish link for logging container,
 # then remove stale PIDs which prevented pgpool from successfully running from a container that is restarted.

--- a/0099FF-stack/web-debug/Dockerfile
+++ b/0099FF-stack/web-debug/Dockerfile
@@ -6,6 +6,13 @@
 #   workflow. Provides a connection to the db (via pgpool), and an additional ENV var (IS_DC_WEB_DEBUG) to
 #   permit settings.py to install the django sslserver, etc for interactive dev.
 #
+# Notes
+# - django ssl server: https://github.com/teddziuba/django-sslserver
+# - to start the ssl server: "python manage.py runsslserver 0.0.0.0:8000"
+# - set the django site_base_url to "0.0.0.0:8000"
+# - responding on any ip address is needed because localhost means something different to the host, host vm (if any), 
+#   within each container.
+#
 # Copyright 2014 - 2016 devops.center
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/0099FF-stack/web/requirements.txt
+++ b/0099FF-stack/web/requirements.txt
@@ -26,4 +26,5 @@ django-ipware==1.1.3
 unicodecsv==0.14.1
 selenium==2.52.0
 objgraph==3.0.0
+enum34==1.1.2
 django-extensions==1.6.1

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-devops_version=v2.0b1
+devops_version=v2.0b2

--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,7 @@ function stack1 {
     mkdir -p 0099FF-stack/web/wheelhouse
     cp ${PWD}/buildtools/pythonwheel/wheelhouse/* 0099FF-stack/web/wheelhouse
     docker build --rm -t "devopscenter/0099ff.web:${devops_version}" 0099FF-stack/web
-    docker build --rm -t "devopscenter/0099ff.web-debug:${devops_verfsion}" 0099FF-stack/web-debug
+    docker build --rm -t "devopscenter/0099ff.web-debug:${devops_version}" 0099FF-stack/web-debug
     docker build --rm -t "devopscenter/0099ff.worker:${devops_version}" 0099FF-stack/worker
 }
 

--- a/build.sh
+++ b/build.sh
@@ -63,6 +63,7 @@ function stack1 {
     mkdir -p 0099FF-stack/web/wheelhouse
     cp ${PWD}/buildtools/pythonwheel/wheelhouse/* 0099FF-stack/web/wheelhouse
     docker build --rm -t "devopscenter/0099ff.web:${devops_version}" 0099FF-stack/web
+    docker build --rm -t "devopscenter/0099ff.web-debug:${devops_verfsion}" 0099FF-stack/web-debug
     docker build --rm -t "devopscenter/0099ff.worker:${devops_version}" 0099FF-stack/worker
 }
 

--- a/push.sh
+++ b/push.sh
@@ -48,6 +48,7 @@ function misc {
 
 function stack1 {
     docker push  "devopscenter/0099ff.web:${devops_version}" 
+    docker push  "devopscenter/0099ff.web:${devops_version}"
     docker push  "devopscenter/0099ff.worker:${devops_version}" 
 }
 


### PR DESCRIPTION
Created a web-debug container for stack 0099FF; the approach can be replicated for any other app-specific stack.

The web-debug container adds in an ENV var to indicate that it's in the web-debug container as opposed to the ordinary web container. Is designed to work with django sslserver.