### PR TITLE
break out scipy and scikit-learn into 2nd install, compiled from source

### DIFF
--- a/0099ff-stack/web/requirements.txt
+++ b/0099ff-stack/web/requirements.txt
@@ -33,14 +33,10 @@ cryptography==1.2.3
 #
 # These four have intricate inter-dependencies. Note that these versions are fairly old (4 years), currently constrained
 # by the versions supported on Heroku via this buildpack: https://github.com/thenovices/heroku-buildpack-scipy
-#
+# In order to build scipy and scikit-learn in a way compatible with numpy, they need to be done in a 2nd step using --no-use-wheel.
+# https://stackoverflow.com/questions/40845304/runtimewarning-numpy-dtype-size-changed-may-indicate-binary-incompatibility
 numpy==1.8.1
 pandas==0.14.1
-scipy==0.14.0
-scikit-learn==0.15.1
 
-# 
-# These are only required on Heroku
-#
-gunicorn==19.1.1
-whitenoise==1.0.5
+#scipy==0.14.0
+#scikit-learn==0.15.1

--- a/0099ff-stack/web/requirements2.txt
+++ b/0099ff-stack/web/requirements2.txt
@@ -1,0 +1,5 @@
+# In order to build scipy and scikit-learn in a way compatible with numpy, they need to be done in a 2nd step using --no-use-wheel.
+# https://stackoverflow.com/questions/40845304/runtimewarning-numpy-dtype-size-changed-may-indicate-binary-incompatibility
+
+scipy==0.14.0
+scikit-learn==0.15.1

--- a/0099ff-stack/web/web.sh
+++ b/0099ff-stack/web/web.sh
@@ -4,5 +4,6 @@ source /usr/local/bin/dcEnv.sh                       # initalize logging environ
 dcStartLog "install of app-specific web for 0099ff"
 
 sudo pip install -r requirements.txt
+sudo pip install --no-use-wheel -r requirements2.txt
 
 dcEndLog "install of app-specific web for 0099ff"


### PR DESCRIPTION
Turns out that finally figured out a fix for that persistent (numpy has changed size) problem, and that's to compile scipy and scikit-learn from source, after numpy and pandas are installed.

So that's what this PR does.