### PR TITLE
66ccff: run one celery worker per queue, independent concurrency.

### DIFF
--- a/66ccff-stack/web/web.sh
+++ b/66ccff-stack/web/web.sh
@@ -38,7 +38,11 @@ sudo npm install -g less
 sudo pip install -r requirements.txt
 
 # 
-# Required directories for this app
+# Required directories for this app. Note that this app requires a /media/data mountpoint prior to the execution
+# of this script, whether provided by docker-compose (in containers) or by the instance creation.
+# While simply creating a /media/data directory in the case where there is no temp volume would permit the app to run,
+# the lackof space on the normal root volume would result in app failure fairly soon.
+# Consequently, the best solution for this app is to simply specify an adequate scratch volume, mounted on /media/data.
 #
 if [[ "${SCRATCHVOLUME}" == "true" ]]; then
     sudo ln -s /media/data /data/media 

--- a/66ccff-stack/worker/conf/run_celery-history.sh
+++ b/66ccff-stack/worker/conf/run_celery-history.sh
@@ -12,7 +12,7 @@ fi
 
 # Create a worker for all queues
 sudo -Eu celery /usr/local/opt/python/bin/python manage.py celery worker \
-                                           --loglevel=INFO --soft-time-limit=300  \
-                                           -c 2 -Q pdfprinttaskqueue,plangeneratorqueue,processhistoryqueue,processmidmonthqueue \
-                                           -n pdf_printer@%n \
-                                           --pidfile=/var/run/celery/pdf_printer.pid
+                                           --loglevel=INFO --soft-time-limit=36000  \
+                                           -c 6 -Q processhistoryqueue \
+                                           -n process_history@%n \
+                                           --pidfile=/var/run/celery/process_history.pid

--- a/66ccff-stack/worker/conf/run_celery-midmonth.sh
+++ b/66ccff-stack/worker/conf/run_celery-midmonth.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+ 
+# This script is run by Supervisor to start celery in foreground mode
+
+# Create the socket directories, if it doesn't already exist.
+ 
+if [ ! -d /var/run/celery ]; then
+    sudo mkdir /var/run/celery
+    sudo chown celery:celery /var/run/celery
+fi
+
+
+# Create a worker for all queues
+sudo -Eu celery /usr/local/opt/python/bin/python manage.py celery worker \
+                                           --loglevel=INFO --soft-time-limit=36000  \
+                                           -c 6 -Q processmidmonthqueue \
+                                           -n process_midmonth@%n \
+                                           --pidfile=/var/run/celery/process_midmonth.pid

--- a/66ccff-stack/worker/conf/run_celery-plan.sh
+++ b/66ccff-stack/worker/conf/run_celery-plan.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+ 
+# This script is run by Supervisor to start celery in foreground mode
+
+# Create the socket directories, if it doesn't already exist.
+ 
+if [ ! -d /var/run/celery ]; then
+    sudo mkdir /var/run/celery
+    sudo chown celery:celery /var/run/celery
+fi
+
+
+# Create a worker for all queues
+sudo -Eu celery /usr/local/opt/python/bin/python manage.py celery worker \
+                                           --loglevel=INFO --soft-time-limit=36000  \
+                                           -c 6 -Q plangeneratorqueue \
+                                           -n plan_generator@%n \
+                                           --pidfile=/var/run/celery/plan_generator.pid

--- a/66ccff-stack/worker/conf/run_celery-print.sh
+++ b/66ccff-stack/worker/conf/run_celery-print.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+ 
+# This script is run by Supervisor to start celery in foreground mode
+
+# Create the socket directories, if it doesn't already exist.
+ 
+if [ ! -d /var/run/celery ]; then
+    sudo mkdir /var/run/celery
+    sudo chown celery:celery /var/run/celery
+fi
+
+
+# Create a worker for all queues
+sudo -Eu celery /usr/local/opt/python/bin/python manage.py celery worker \
+                                           --loglevel=INFO --soft-time-limit=36000  \
+                                           -c 6 -Q pdfprinttaskqueue \
+                                           -n pdf_printer@%n \
+                                           --pidfile=/var/run/celery/pdf_printer.pid

--- a/66ccff-stack/worker/conf/supervisor-celery.conf
+++ b/66ccff-stack/worker/conf/supervisor-celery.conf
@@ -2,9 +2,78 @@
 ;  celery worker supervisor example
 ; ==================================
 
-[program:celery]
-; Set full path to celery program if using virtualenv
-command=/etc/supervisor/conf.d/run_celery.sh 
+[group:celery]
+programs=celery_plan_generator,celery_pdf_printer,celery_process_history,celery_process_midmonth
+priority=9999
+
+[program:celery_plan_generator]
+command=/etc/supervisor/conf.d/run_celery-plan.sh 
+directory=/data/deploy/current
+numprocs=1
+autostart=true
+autorestart=true
+startsecs=10
+
+; Need to wait for currently executing tasks to finish at shutdown.
+; Increase this if you have very long running tasks.
+stopwaitsecs = 600
+
+; Supervisor struggles with killing celery workers. Next two settings appear to best combo
+; (from https://github.com/Supervisor/supervisor/issues/721#issuecomment-184862648)
+stopasgroup=true
+stopsignal=INT
+
+priority=999
+
+stdout_logfile=syslog
+stderr_logfile=syslog
+
+[program:celery_pdf_printer]
+command=/etc/supervisor/conf.d/run_celery-print.sh 
+directory=/data/deploy/current
+numprocs=1
+autostart=true
+autorestart=true
+startsecs=10
+
+; Need to wait for currently executing tasks to finish at shutdown.
+; Increase this if you have very long running tasks.
+stopwaitsecs = 600
+
+; Supervisor struggles with killing celery workers. Next two settings appear to best combo
+; (from https://github.com/Supervisor/supervisor/issues/721#issuecomment-184862648)
+stopasgroup=true
+stopsignal=INT
+
+priority=999
+
+stdout_logfile=syslog
+stderr_logfile=syslog
+
+[program:celery_process_history]
+command=/etc/supervisor/conf.d/run_celery-history.sh 
+directory=/data/deploy/current
+numprocs=1
+autostart=true
+autorestart=true
+startsecs=10
+
+; Need to wait for currently executing tasks to finish at shutdown.
+; Increase this if you have very long running tasks.
+stopwaitsecs = 600
+
+; Supervisor struggles with killing celery workers. Next two settings appear to best combo
+; (from https://github.com/Supervisor/supervisor/issues/721#issuecomment-184862648)
+stopasgroup=true
+stopsignal=INT
+
+priority=999
+
+stdout_logfile=syslog
+stderr_logfile=syslog
+
+[program:celery_process_midmonth]
+command=/etc/supervisor/conf.d/run_celery-midmonth.sh 
 directory=/data/deploy/current
 numprocs=1
 autostart=true

--- a/66ccff-stack/worker/worker.sh
+++ b/66ccff-stack/worker/worker.sh
@@ -45,7 +45,7 @@ fi
 #
 sudo cp conf/supervisor-flower.conf /etc/supervisor/conf.d/flower.conf 
 sudo cp conf/supervisor-celery.conf /etc/supervisor/conf.d/celery.conf
-sudo cp conf/run_celery.sh /etc/supervisor/conf.d/run_celery.sh
+sudo cp conf/run_*.sh /etc/supervisor/conf.d/
 
 
 dcEndLog "install of app-specific worker for 66ccff, combo: ${COMBINED_WEB_WORKER}"


### PR DESCRIPTION
This is a pattern for other multi-queue celery configs, I think.