### PR TITLE
Enable dynamic ENV for 0099ff worker (djangorq), clean UWSGI config

### DIFF
--- a/0099ff-stack/worker/conf/run_djangorq.sh
+++ b/0099ff-stack/worker/conf/run_djangorq.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script is run by Supervisor to start a single django-rq worker in this process.
+# 
+# Supports dynamic ENV variables that can be set during each deplay.
+# (e.g. can be used to set GIT_SHA, to establish "releases" for Sentry)
+#
+# The environment variables are specified in dynamics_env.ini, in the [default] section.
+# E.g.
+#       [default]
+#       GIT_SHA=823674826428642838628346
+#       OTHER_VALUE=a string
+#
+# This file does not currently support comments.
+# https://stackoverflow.com/a/28794976/8417759
+
+# Start by reading in and setting dynamic environment vars.
+source <(grep = /data/deploy/current/dynamic_env.ini)
+
+exec python manage.py rqworker default
+

--- a/0099ff-stack/worker/conf/supervisor-djangorq-worker.conf
+++ b/0099ff-stack/worker/conf/supervisor-djangorq-worker.conf
@@ -1,5 +1,5 @@
 [program:djangorq-worker]
-command=python manage.py rqworker default
+command=/etc/supervisor/conf.d/run_djangorq.sh
 directory=/data/deploy/current
 
 

--- a/web/python-nginx/conf/run_uwsgi.sh
+++ b/web/python-nginx/conf/run_uwsgi.sh
@@ -11,6 +11,8 @@ fi
 exec /usr/local/opt/python/bin/uwsgi \
         --enable-threads \
         --master-fifo /tmp/uwsgififo \
+        --workers=${UWSGI_WORKERS} \
+        --max-requests=${UWSGI_MAX_REQUESTS} \
         --lazy-apps \
         --hook-post-fork="chdir:/data/deploy/current" \
         /data/deploy/current/uwsgi.ini


### PR DESCRIPTION
This branch does two things:
- supports the setting of dynamic ENV vars in django-rq workers (in 0099ff so far)
- sets a couple of uwsgi settings from the per-env configs, rather than the app repo (e.g. the number of worker processes).

Coordinates with changes made in the app repo, app utils, and django-code-deploy.