### PR TITLE
Docker Compose Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ buildtoolspush.log
 buildtools/pythonwheel/wheelhouse/*
 
 .vagrant/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ buildtools.log
 jenkins.log
 buildtoolspush.log
 buildtools/pythonwheel/wheelhouse/*
+
+.vagrant/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ os:
   - linux
 sudo: required
 
+#https://docs.travis-ci.com/user/docker/
 env:
   - DOCKER_COMPOSE_VERSION=1.16.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 os:
   - linux
 sudo: required
+
+env:
+  - DOCKER_COMPOSE_VERSION=1.16.1
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
 script:
   - travis_wait ./travis.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ADD buildtools/utils/base-utils.sh /installs/base-utils.sh
 ADD buildtools/utils/dcEnv.sh /installs/dcEnv.sh
 
 # Add the files needed to install & configure tmux
+ADD buildtools/utils/tmuxinstall.sh /installs/tmuxinstall.sh
 ADD buildtools/utils/tmux.conf /installs/tmux.conf
 ADD buildtools/utils/bash_profile /installs/bash_profile
 ADD buildtools/utils/bashrc /installs/bashrc

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,2 @@
+dcPREFIX=devopsscion
 dcSTACK_VERSION=v2.0

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,48 +69,11 @@ Vagrant.configure(2) do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  config.vm.provision "shell", inline: <<-SHELL
-     pushd /home/encoders
-     pushd haggle
-     ./dependencies_ubuntu.sh
-     popd
-     sudo apt-get -y install gcc-4.9
-     sudo apt-get -y install g++-4.9
-     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 49 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
-     sudo update-alternatives --set gcc "/usr/bin/gcc-4.9"
-  SHELL
-
-  $haggleinstall=<<-SCRIPT
-    pushd /home/encoders
-    pushd charm
-    ./build_ubuntu.sh
-    popd
-    pushd haggle 
-    ./build_ubuntu.sh
-    popd
-  SCRIPT
-
-  $evaluationinstall=<<-SCRIPT
-    pushd /home/ubuntu
-    git clone https://github.com/internetofvehicles/ENCODERS encodersevaluation
-    pushd encodersevaluation
-    git checkout evaluation
-    git pull
-    pushd setup/tools/
-    ./dependencies_ubuntu.sh
-    ./install_ubuntu.sh
-    popd
-    #make sure execute permissions set for scripts
-    find ./ -name "*.sh" -exec chmod +x {} \;
-  SCRIPT
-
   $dockerinstall=<<-SCRIPT
     pushd /vagrant
     ./install_docker.sh 
     popd
   SCRIPT
 
-  #config.vm.provision "shell", inline: $haggleinstall, privileged: false
-  #config.vm.provision "shell", inline: $evaluationinstall, privileged: false
   config.vm.provision "shell", inline: $dockerinstall, privileged: false
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,116 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/xenial64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/vagrant"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "4096"]
+    vb.customize ["modifyvm", :id, "--cpus", "4"]
+  end
+
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+     pushd /home/encoders
+     pushd haggle
+     ./dependencies_ubuntu.sh
+     popd
+     sudo apt-get -y install gcc-4.9
+     sudo apt-get -y install g++-4.9
+     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 49 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
+     sudo update-alternatives --set gcc "/usr/bin/gcc-4.9"
+  SHELL
+
+  $haggleinstall=<<-SCRIPT
+    pushd /home/encoders
+    pushd charm
+    ./build_ubuntu.sh
+    popd
+    pushd haggle 
+    ./build_ubuntu.sh
+    popd
+  SCRIPT
+
+  $evaluationinstall=<<-SCRIPT
+    pushd /home/ubuntu
+    git clone https://github.com/internetofvehicles/ENCODERS encodersevaluation
+    pushd encodersevaluation
+    git checkout evaluation
+    git pull
+    pushd setup/tools/
+    ./dependencies_ubuntu.sh
+    ./install_ubuntu.sh
+    popd
+    #make sure execute permissions set for scripts
+    find ./ -name "*.sh" -exec chmod +x {} \;
+  SCRIPT
+
+  $dockerinstall=<<-SCRIPT
+    pushd /vagrant
+    ./install_docker.sh 
+    popd
+  SCRIPT
+
+  #config.vm.provision "shell", inline: $haggleinstall, privileged: false
+  #config.vm.provision "shell", inline: $evaluationinstall, privileged: false
+  config.vm.provision "shell", inline: $dockerinstall, privileged: false
+end

--- a/buildtools/utils/base-utils.sh
+++ b/buildtools/utils/base-utils.sh
@@ -51,8 +51,9 @@ sudo apt-fast -qq -y install git wget sudo vim unzip curl language-pack-en jq
 
 sudo apt-fast -y install ncdu ntp fail2ban htop
 
-sudo apt-fast -y install tmux-next
-sudo mv /usr/bin/tmux-next /usr/bin/tmux
+./tmuxinstall.sh
+#sudo apt-fast -y install tmux-next
+#sudo mv /usr/bin/tmux-next /usr/bin/tmux
 
 pushd /tmp
 curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"

--- a/buildtools/utils/base-utils.sh
+++ b/buildtools/utils/base-utils.sh
@@ -47,7 +47,7 @@ sudo add-apt-repository -y ppa:saiarcot895/myppa && \
     sudo apt-get -qq update && \
     sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -y install apt-fast
 
-sudo apt-fast -qq -y install git wget sudo vim unzip curl language-pack-en jq
+sudo apt-fast -qq -y install git wget sudo vim unzip curl language-pack-en jq build-essential
 
 sudo apt-fast -y install ncdu ntp fail2ban htop
 

--- a/buildtools/utils/base-utils.sh
+++ b/buildtools/utils/base-utils.sh
@@ -51,6 +51,7 @@ sudo apt-fast -qq -y install git wget sudo vim unzip curl language-pack-en jq
 
 sudo apt-fast -y install ncdu ntp fail2ban htop
 
+
 ./tmuxinstall.sh
 #sudo apt-fast -y install tmux-next
 #sudo mv /usr/bin/tmux-next /usr/bin/tmux

--- a/buildtools/utils/tmuxinstall.sh
+++ b/buildtools/utils/tmuxinstall.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ev
+
+#https://gist.github.com/P7h/91e14096374075f5316e
+
+pushd /tmp
+# Steps to build and install tmux from source on Ubuntu.
+# Takes < 25 seconds on EC2 env [even on a low-end config instance].
+VERSION=2.6
+sudo apt-get -y remove tmux
+sudo apt-get -y install wget tar libevent-dev libncurses-dev
+wget https://github.com/tmux/tmux/releases/download/${VERSION}/tmux-${VERSION}.tar.gz
+tar xf tmux-${VERSION}.tar.gz
+rm -f tmux-${VERSION}.tar.gz
+cd tmux-${VERSION}
+./configure
+make
+sudo make install
+cd -
+sudo rm -rf /usr/local/src/tmux-*
+sudo mv tmux-${VERSION} /usr/local/src
+popd
+
+## Logout and login to the shell again and run.
+## tmux -V

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -3,21 +3,21 @@ services:
     #base
     base:
         build: .
-        image: devopsscion/base
+        image: ${dcPREFIX}/base:${dcSTACK_VERSION}
 
     #python
     python:
         build: python
-        image: devopsscion/python
+        image: ${dcPREFIX}/python:${dcSTACK_VERSION}
         depends_on: 
           - base
     python-nginx:
         build: web/python-nginx
-        image: devopsscion/python-nginx
+        image: ${dcPREFIX}/python-nginx:${dcSTACK_VERSION}
         depends_on:
           - python
     python-nginx-pgpool:
         build: web/python-nginx-pgpool
-        image: devopsscion/python-nginx-pgpool
+        image: ${dcPREFIX}/python-nginx-pgpool:${dcSTACK_VERSION}
         depends_on:
           - python-nginx

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -7,7 +7,7 @@ web:
     python:
         build: python
         image: devopsscion/python
-    python-nginx
+    python-nginx:
         build: web/python-nginx
         image: devopsscion/python-nginx
     python-nginx-pgpool:

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -1,9 +1,11 @@
 version: '3'
-basecontainer:
+services:
+    #base
     base:
         build: .
         image: devopsscion/base
-web:
+
+    #python
     python:
         build: python
         image: devopsscion/python

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -9,9 +9,15 @@ services:
     python:
         build: python
         image: devopsscion/python
+        depends_on: 
+          - base
     python-nginx:
         build: web/python-nginx
         image: devopsscion/python-nginx
+        depends_on:
+          - python
     python-nginx-pgpool:
         build: web/python-nginx-pgpool
         image: devopsscion/python-nginx-pgpool
+        depends_on:
+          - python-nginx

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -1,0 +1,15 @@
+version: '3'
+basecontainer:
+    base:
+        build: .
+        image: devopsscion/base
+web:
+    python:
+        build: python
+        image: devopsscion/python
+    python-nginx
+        build: web/python-nginx
+        image: devopsscion/python-nginx
+    python-nginx-pgpool:
+        build: web/python-nginx-pgpool
+        image: devopsscion/python-nginx-pgpool

--- a/env-docker.sh
+++ b/env-docker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ev
+
+cat VERSION > .env
+

--- a/install_docker.sh
+++ b/install_docker.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -ev
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update
+sudo apt-cache policy docker-ce
+sudo apt-get install -y docker-ce
+
+sudo curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+

--- a/python/python.sh
+++ b/python/python.sh
@@ -78,7 +78,7 @@ sudo ln -s /usr/local/opt/python/bin/python /usr/local/bin/python
 which python && python --version
 
 pushd /tmp
-wget --quiet https://bootstrap.pypa.io/get-pip.py && python get-pip.py
+wget --quiet https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
 #force overwrite
 sudo ln -fs /usr/local/opt/python/bin/pip /usr/local/bin/pip
 

--- a/python/python.sh
+++ b/python/python.sh
@@ -66,10 +66,10 @@ popd
 sudo apt-fast -qq -y install sqlite3 libsqlite3-dev libssl-dev zlib1g-dev libxml2-dev libxslt-dev libbz2-dev gfortran libopenblas-dev liblapack-dev libatlas-dev subversion
 
 pushd /tmp
-sudo wget --quiet https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz -O /tmp/Python-${PYTHON_VERSION}.tgz
-sudo tar -xvf Python-${PYTHON_VERSION}.tgz
+wget --quiet https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz -O /tmp/Python-${PYTHON_VERSION}.tgz
+tar -xvf Python-${PYTHON_VERSION}.tgz
 pushd Python-${PYTHON_VERSION}
-sudo ./configure CFLAGSFORSHARED="-fPIC" CCSHARED="-fPIC" --quiet CCSHARED="-fPIC" --prefix=/usr/local/opt/python --exec-prefix=/usr/local/opt/python CCSHARED="-fPIC" \
+./configure CFLAGSFORSHARED="-fPIC" CCSHARED="-fPIC" --quiet CCSHARED="-fPIC" --prefix=/usr/local/opt/python --exec-prefix=/usr/local/opt/python CCSHARED="-fPIC" \
             && make clean && make --silent -j3 && sudo make --silent install
 popd
 

--- a/python/python.sh
+++ b/python/python.sh
@@ -78,8 +78,9 @@ sudo ln -s /usr/local/opt/python/bin/python /usr/local/bin/python
 which python && python --version
 
 pushd /tmp
-sudo wget --quiet https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
-sudo ln -s /usr/local/opt/python/bin/pip /usr/local/bin/pip
+wget --quiet https://bootstrap.pypa.io/get-pip.py && python get-pip.py
+#force overwrite
+sudo ln -fs /usr/local/opt/python/bin/pip /usr/local/bin/pip
 
 sudo pip install -U setuptools-git wheel virtualenv
 

--- a/travis.sh
+++ b/travis.sh
@@ -41,6 +41,9 @@ set -o verbose
 echo "PATH=/usr/local/opt/python/bin:$PATH" | sudo tee -a /etc/environment
 . /etc/environment
 
+
+docker-compose -f docker-compose-build.yml build
+
 pushd buildtools/utils
 ./base-utils.sh
 popd

--- a/travis.sh
+++ b/travis.sh
@@ -43,6 +43,7 @@ echo "PATH=/usr/local/opt/python/bin:$PATH" | sudo tee -a /etc/environment
 
 #https://docs.docker.com/compose/reference/push/
 #build and then push
+./name.sh
 docker-compose -f docker-compose-build.yml build
 
 pushd buildtools/utils

--- a/travis.sh
+++ b/travis.sh
@@ -44,6 +44,7 @@ echo "PATH=/usr/local/opt/python/bin:$PATH" | sudo tee -a /etc/environment
 #https://docs.docker.com/compose/reference/push/
 #build and then push
 ./name.sh
+./env-docker.sh
 docker-compose -f docker-compose-build.yml build
 
 pushd buildtools/utils

--- a/travis.sh
+++ b/travis.sh
@@ -45,7 +45,7 @@ echo "PATH=/usr/local/opt/python/bin:$PATH" | sudo tee -a /etc/environment
 #build and then push
 ./name.sh
 ./env-docker.sh
-docker-compose -f docker-compose-build.yml build
+sudo docker-compose -f docker-compose-build.yml build
 
 pushd buildtools/utils
 ./base-utils.sh
@@ -71,25 +71,13 @@ pushd web/python-nginx-pgpool
 ./pgpool.sh > /dev/null
 popd
 
-pushd web/python-nginx-pgpool-libsodium
-git clone https://github.com/devopsscion/libsodium-jni
-git clone https://github.com/data-luminosity/message
-    pushd libsodium-jni
-    ./build-linux.sh > /dev/null
-    popd
-
-    pushd message
-    sudo pip install -r requirements.txt > /dev/null
-    popd
-popd
-
-pushd db/postgres
-sudo /etc/init.d/postgresql stop
-sudo apt-get --purge remove postgresql\*
-sudo rm -rf /etc/postgresql/
-sudo rm -rf /etc/postgresql-common/
-sudo rm -rf /var/lib/postgresql/
-sudo userdel -r postgres
+#pushd db/postgres
+#sudo /etc/init.d/postgresql stop
+#sudo apt-get --purge remove postgresql\*
+#sudo rm -rf /etc/postgresql/
+#sudo rm -rf /etc/postgresql-common/
+#sudo rm -rf /var/lib/postgresql/
+#sudo userdel -r postgres
 #sudo groupdel postgres
 #./postgres.sh > /dev/null
-popd
+#popd

--- a/travis.sh
+++ b/travis.sh
@@ -57,6 +57,10 @@ pushd python
 ./python.sh > /dev/null
 popd
 
+pushd buildtools/utils
+./install-supervisor.sh custom
+popd
+
 pushd web/python-nginx
 ./nginx.sh > /dev/null
 popd

--- a/travis.sh
+++ b/travis.sh
@@ -41,7 +41,8 @@ set -o verbose
 echo "PATH=/usr/local/opt/python/bin:$PATH" | sudo tee -a /etc/environment
 . /etc/environment
 
-
+#https://docs.docker.com/compose/reference/push/
+#build and then push
 docker-compose -f docker-compose-build.yml build
 
 pushd buildtools/utils


### PR DESCRIPTION
Uses docker compose to build the stacks, instead of the scripts. Can also then use docker compose to push the containers, rather than the scripts.

Working travis build.

Vagrant setup.