### PR TITLE
Build with env variables

### DIFF
--- a/000000-stack/web-debug/Dockerfile
+++ b/000000-stack/web-debug/Dockerfile
@@ -28,7 +28,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/000000.web:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/000000.web:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ENV IS_DC_WEB_DEBUG=1

--- a/000000-stack/web-debug/Dockerfile
+++ b/000000-stack/web-debug/Dockerfile
@@ -28,8 +28,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/000000.web:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/000000.web:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ENV IS_DC_WEB_DEBUG=1

--- a/000000-stack/web/Dockerfile
+++ b/000000-stack/web/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python-nginx-pgpool-redis:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 WORKDIR /installs

--- a/000000-stack/web/Dockerfile
+++ b/000000-stack/web/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 WORKDIR /installs

--- a/000000-stack/worker/Dockerfile
+++ b/000000-stack/worker/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/000000.web:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/000000.web:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 # Setup config to run pgpool and a single django-rq worker in this container

--- a/000000-stack/worker/Dockerfile
+++ b/000000-stack/worker/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/000000.web:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/000000.web:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 # Setup config to run pgpool and a single django-rq worker in this container

--- a/007acc-stack/web/Dockerfile
+++ b/007acc-stack/web/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python-nginx-pgpool-redis:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 WORKDIR /installs

--- a/007acc-stack/web/Dockerfile
+++ b/007acc-stack/web/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 WORKDIR /installs

--- a/007acc-stack/worker/Dockerfile
+++ b/007acc-stack/worker/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/007acc.web:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/007acc.web:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 # Flower port

--- a/007acc-stack/worker/Dockerfile
+++ b/007acc-stack/worker/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/007acc.web:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/007acc.web:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 # Flower port

--- a/0099ff-stack/web-debug/Dockerfile
+++ b/0099ff-stack/web-debug/Dockerfile
@@ -28,8 +28,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/0099ff.web:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/0099ff.web:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ENV IS_DC_WEB_DEBUG=1

--- a/0099ff-stack/web-debug/Dockerfile
+++ b/0099ff-stack/web-debug/Dockerfile
@@ -28,7 +28,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/0099ff.web:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/0099ff.web:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ENV IS_DC_WEB_DEBUG=1

--- a/0099ff-stack/web/Dockerfile
+++ b/0099ff-stack/web/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python-nginx-pgpool-redis:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 WORKDIR /installs

--- a/0099ff-stack/web/Dockerfile
+++ b/0099ff-stack/web/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 WORKDIR /installs

--- a/0099ff-stack/worker/Dockerfile
+++ b/0099ff-stack/worker/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/0099ff.web:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/0099ff.web:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 

--- a/0099ff-stack/worker/Dockerfile
+++ b/0099ff-stack/worker/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/0099ff.web:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/0099ff.web:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 

--- a/42fca0-stack/web/Dockerfile
+++ b/42fca0-stack/web/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSITE_TAG}
 MAINTAINER admin < admin [at] devops {dot} center>
 
 ADD web.sh /installs/web.sh

--- a/42fca0-stack/web/Dockerfile
+++ b/42fca0-stack/web/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python-nginx-pgpool-redis:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
 MAINTAINER admin < admin [at] devops {dot} center>
 
 ADD web.sh /installs/web.sh

--- a/66ccff-stack/web/Dockerfile
+++ b/66ccff-stack/web/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python-nginx-pgpool-redis:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 WORKDIR /installs

--- a/66ccff-stack/web/Dockerfile
+++ b/66ccff-stack/web/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 WORKDIR /installs

--- a/66ccff-stack/worker/Dockerfile
+++ b/66ccff-stack/worker/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/66ccff.web:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/66ccff.web:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 # Flower port

--- a/66ccff-stack/worker/Dockerfile
+++ b/66ccff-stack/worker/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/66ccff.web:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/66ccff.web:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 # Flower port

--- a/765ae2-stack/web/Dockerfile
+++ b/765ae2-stack/web/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python-nginx-pgpool:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python-nginx-pgpool:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 WORKDIR /installs

--- a/765ae2-stack/web/Dockerfile
+++ b/765ae2-stack/web/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python-nginx-pgpool:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python-nginx-pgpool:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 WORKDIR /installs

--- a/765ae2-stack/worker/Dockerfile
+++ b/765ae2-stack/worker/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/007acc.web:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/007acc.web:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 # Flower port

--- a/765ae2-stack/worker/Dockerfile
+++ b/765ae2-stack/worker/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/007acc.web:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/007acc.web:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 # Flower port

--- a/9900af-stack/web-debug/Dockerfile
+++ b/9900af-stack/web-debug/Dockerfile
@@ -28,8 +28,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/9900af.web:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/9900af.web:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ENV IS_DC_WEB_DEBUG=1

--- a/9900af-stack/web-debug/Dockerfile
+++ b/9900af-stack/web-debug/Dockerfile
@@ -28,7 +28,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/9900af.web:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/9900af.web:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ENV IS_DC_WEB_DEBUG=1

--- a/9900af-stack/web/Dockerfile
+++ b/9900af-stack/web/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python-nginx-pgpool-redis:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 WORKDIR /installs

--- a/9900af-stack/web/Dockerfile
+++ b/9900af-stack/web/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 WORKDIR /installs

--- a/9900af-stack/worker/Dockerfile
+++ b/9900af-stack/worker/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/9900af.web:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/9900af.web:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 # Setup config to run pgpool and a single django-rq worker in this container

--- a/9900af-stack/worker/Dockerfile
+++ b/9900af-stack/worker/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/9900af.web:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/9900af.web:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 # Setup config to run pgpool and a single django-rq worker in this container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM baseimageversion
+ARG baseimageversion
+FROM ${baseimageversion}
 
 # Since ubuntu 16.04 has dropped sudo, need to
 # install sudo for compatibility with scripts that also run in instances

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-dcSTACK_VERSION=v2.1.1-postgres9.4
+dcSTACK_VERSION=v2.1.2
 

--- a/ab0000-stack/web/Dockerfile
+++ b/ab0000-stack/web/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python-nginx-pgpool-redis:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 WORKDIR /installs

--- a/ab0000-stack/web/Dockerfile
+++ b/ab0000-stack/web/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 WORKDIR /installs

--- a/build.sh
+++ b/build.sh
@@ -45,95 +45,95 @@ echo "BaseImage=${baseimageversion}"
 source POSTGRES_VERSION
 echo "Postgresql version=${postgresVerison}"
 
-COMPOSIT_TAG=${dcSTACK_VERSION}-postgres${postgresVersion}
+COMPOSITE_TAG=${dcSTACK_VERSION}-postgres${postgresVersion}
 
 #build containers
 
 function base {
-    docker build --rm --build-arg baseimageversion=${baseimageversion} -t "devopscenter/base:${COMPOSIT_TAG}" .
+    docker build --rm --build-arg baseimageversion=${baseimageversion} -t "devopscenter/base:${COMPOSITE_TAG}" .
 }
 
 function db {
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/db_base:${COMPOSIT_TAG}" db
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/db_postgres:${COMPOSIT_TAG}" db/postgres
-#    docker build --rm -t "devopscenter/db_postgres-standby:${COMPOSIT_TAG}" db/postgres-standby
-#   docker build --rm -t "devopscenter/db_postgres-repmgr:${COMPOSIT_TAG}" db/postgres-repmgr
-#   docker build --rm -t "devopscenter/db_postgres-restore:${COMPOSIT_TAG}" db/postgres-restore
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/db_redis:${COMPOSIT_TAG}" db/redis
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/db_redis-standby:${COMPOSIT_TAG}" db/redis-standby
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/db_base:${COMPOSITE_TAG}" db
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/db_postgres:${COMPOSITE_TAG}" db/postgres
+#    docker build --rm -t "devopscenter/db_postgres-standby:${COMPOSITE_TAG}" db/postgres-standby
+#   docker build --rm -t "devopscenter/db_postgres-repmgr:${COMPOSITE_TAG}" db/postgres-repmgr
+#   docker build --rm -t "devopscenter/db_postgres-restore:${COMPOSITE_TAG}" db/postgres-restore
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/db_redis:${COMPOSITE_TAG}" db/redis
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/db_redis-standby:${COMPOSITE_TAG}" db/redis-standby
 }
 
 function misc {
-    docker build --rm --build-arg baseimageversion=${baseimageversion} -t "devopscenter/syslog:${COMPOSIT_TAG}" logging/. &> syslog.log &
-    docker build --rm --build-arg baseimageversion=${baseimageversion} -t "devopscenter/monitor_papertrail:${COMPOSIT_TAG}" monitor/papertrail &> papertrail.log &
-    docker build --rm -t "devopscenter/monitor_sentry:${COMPOSIT_TAG}" monitor/sentry &> sentry.log &
-    docker build --rm -t "devopscenter/monitor_nagios:${COMPOSIT_TAG}" monitor/nagios &> nagios.log &
+    docker build --rm --build-arg baseimageversion=${baseimageversion} -t "devopscenter/syslog:${COMPOSITE_TAG}" logging/. &> syslog.log &
+    docker build --rm --build-arg baseimageversion=${baseimageversion} -t "devopscenter/monitor_papertrail:${COMPOSITE_TAG}" monitor/papertrail &> papertrail.log &
+    docker build --rm -t "devopscenter/monitor_sentry:${COMPOSITE_TAG}" monitor/sentry &> sentry.log &
+    docker build --rm -t "devopscenter/monitor_nagios:${COMPOSITE_TAG}" monitor/nagios &> nagios.log &
 }
-# docker build --rm -t "devopscenter/loadbalancer_ssl-termination:${COMPOSIT_TAG}" loadbalancer/ssl-termination
-# docker build --rm -t "devopscenter/loadbalancer_haproxy:${COMPOSIT_TAG}" loadbalancer/haproxy
+# docker build --rm -t "devopscenter/loadbalancer_ssl-termination:${COMPOSITE_TAG}" loadbalancer/ssl-termination
+# docker build --rm -t "devopscenter/loadbalancer_haproxy:${COMPOSITE_TAG}" loadbalancer/haproxy
 
 function newrelic {
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/monitor_newrelic:${COMPOSIT_TAG}" monitor/newrelic &
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/monitor_newrelic:${COMPOSITE_TAG}" monitor/newrelic &
 }
 
 function backups {
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/db_postgres-backup:${COMPOSIT_TAG}" db/postgres-backup
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/db_postgres-backup:${COMPOSITE_TAG}" db/postgres-backup
 }
 
 function stack0 {
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/000000.web:${COMPOSIT_TAG}" 000000-stack/web
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/000000.web-debug:${COMPOSIT_TAG}" 000000-stack/web-debug
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/000000.worker:${COMPOSIT_TAG}" 000000-stack/worker
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/000000.web:${COMPOSITE_TAG}" 000000-stack/web
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/000000.web-debug:${COMPOSITE_TAG}" 000000-stack/web-debug
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/000000.worker:${COMPOSITE_TAG}" 000000-stack/worker
 }
 
 function stack1 {
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/0099ff.web:${COMPOSIT_TAG}" 0099ff-stack/web
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/0099ff.web-debug:${COMPOSIT_TAG}" 0099ff-stack/web-debug
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/0099ff.worker:${COMPOSIT_TAG}" 0099ff-stack/worker
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/0099ff.web:${COMPOSITE_TAG}" 0099ff-stack/web
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/0099ff.web-debug:${COMPOSITE_TAG}" 0099ff-stack/web-debug
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/0099ff.worker:${COMPOSITE_TAG}" 0099ff-stack/worker
 }
 
 function stack2 {
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/66ccff.web:${COMPOSIT_TAG}" 66ccff-stack/web
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/66ccff.worker:${COMPOSIT_TAG}" 66ccff-stack/worker
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/66ccff.web:${COMPOSITE_TAG}" 66ccff-stack/web
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/66ccff.worker:${COMPOSITE_TAG}" 66ccff-stack/worker
 }
 
 function stack3 {
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/007acc.web:${COMPOSIT_TAG}" 007acc-stack/web
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/007acc.worker:${COMPOSIT_TAG}" 007acc-stack/worker
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/007acc.web:${COMPOSITE_TAG}" 007acc-stack/web
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/007acc.worker:${COMPOSITE_TAG}" 007acc-stack/worker
 }
 
 function stack4 {
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/9900af.web:${COMPOSIT_TAG}" 9900af-stack/web
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/9900af.worker:${COMPOSIT_TAG}" 9900af-stack/worker
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/9900af.web:${COMPOSITE_TAG}" 9900af-stack/web
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/9900af.worker:${COMPOSITE_TAG}" 9900af-stack/worker
 }
 
 function stack5 {
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/ab0000.web:${COMPOSIT_TAG}" ab0000-stack/web
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/ab0000.web:${COMPOSITE_TAG}" ab0000-stack/web
 }
 
 function stack6 {
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/765ae2.web:${COMPOSIT_TAG}" 765ae2-stack/web
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/765ae2.web:${COMPOSITE_TAG}" 765ae2-stack/web
 }
 
 function web {
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/python:${COMPOSIT_TAG}" python
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/python:${COMPOSITE_TAG}" python
     time newrelic &> newrelic.log &
     time backups &> backups.log &
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/python-nginx:${COMPOSIT_TAG}" web/python-nginx
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/python-nginx-pgpool:${COMPOSIT_TAG}" web/python-nginx-pgpool
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}" web/python-nginx-pgpool-redis
-#    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/python-nginx-pgpool-libsodium:${COMPOSIT_TAG}" web/python-nginx-pgpool-libsodium
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/python-nginx:${COMPOSITE_TAG}" web/python-nginx
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/python-nginx-pgpool:${COMPOSITE_TAG}" web/python-nginx-pgpool
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/python-nginx-pgpool-redis:${COMPOSITE_TAG}" web/python-nginx-pgpool-redis
+#    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/python-nginx-pgpool-libsodium:${COMPOSITE_TAG}" web/python-nginx-pgpool-libsodium
     echo "built common containers"
 }
 
 function web-all {
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/python:${COMPOSIT_TAG}" python
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/python:${COMPOSITE_TAG}" python
     newrelic &> newrelic.log &
     backups &> backups.log &
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/python-nginx:${COMPOSIT_TAG}" web/python-nginx
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/python-nginx-pgpool:${COMPOSIT_TAG}" web/python-nginx-pgpool
-    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}" web/python-nginx-pgpool-redis
-#    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/python-nginx-pgpool-libsodium:${COMPOSIT_TAG}" web/python-nginx-pgpool-libsodium
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/python-nginx:${COMPOSITE_TAG}" web/python-nginx
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/python-nginx-pgpool:${COMPOSITE_TAG}" web/python-nginx-pgpool
+    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/python-nginx-pgpool-redis:${COMPOSITE_TAG}" web/python-nginx-pgpool-redis
+#    docker build --rm --build-arg COMPOSITE_TAG=${COMPOSITE_TAG} -t "devopscenter/python-nginx-pgpool-libsodium:${COMPOSITE_TAG}" web/python-nginx-pgpool-libsodium
     echo "built common containers"
 
 
@@ -162,15 +162,15 @@ else
     #time web-all &> web.log &
     #time db &> db.log &
     postgresVersion=9.4
-    COMPOSIT_TAG=${dcSTACK_VERSION}-postgres${postgresVersion}
-    echo  ${COMPOSIT_TAG}
+    COMPOSITE_TAG=${dcSTACK_VERSION}-postgres${postgresVersion}
+    echo  ${COMPOSITE_TAG}
     base > base9.4.log
     misc &> misc9.4.log &
     web-all &> web9.4.log
     db &> db9.4.log
     postgresVersion=9.6
-    COMPOSIT_TAG=${dcSTACK_VERSION}-postgres${postgresVersion}
-    echo  ${COMPOSIT_TAG}
+    COMPOSITE_TAG=${dcSTACK_VERSION}-postgres${postgresVersion}
+    echo  ${COMPOSITE_TAG}
     base > base9.6.log
     misc &> misc9.6.log &
     web-all &> web9.6.log

--- a/build.sh
+++ b/build.sh
@@ -150,7 +150,7 @@ function web-all {
     rm -rf stack5.log
     stack5 &> stack5.log
     rm -rf stack6.log
-    stack6 &> stack5.log
+    stack6 &> stack6.log
 }
 
 if [[ $# -gt 0 ]]; then

--- a/build.sh
+++ b/build.sh
@@ -43,126 +43,136 @@ echo "Version=${dcSTACK_VERSION}"
 source BASEIMAGE
 echo "BaseImage=${baseimageversion}"
 source POSTGRES_VERSION
-echo "Postgresql version=${postgreVerison}"
+echo "Postgresql version=${postgresVerison}"
 
-#replace variable dcSTACK_VERSION with the VERSION we are building
-find . -name "Dockerfile" -type f -print -exec sed -i -e "s/dcSTACK_VERSION/$dcSTACK_VERSION/g" {} \;
-find . -name "Dockerfile" -type f -print -exec sed -i -e "s~baseimageversion~$baseimageversion~g" {} \;
-find . -name "Dockerfile" -type f -print -exec sed -i -e "s/ENV POSTGRES_VERSION .*/ENV POSTGRES_VERSION $postgresVersion/g" {} \;
-sed -i -e "s/^POSTGRES_VERSION=.*/POSTGRES_VERSION=$postgresVersion/" db/postgres/postgresenv.sh
-sed -i -e "s/^POSTGRES_VERSION=.*/POSTGRES_VERSION=$postgresVersion/" web/python-nginx-pgpool/pgpoolenv.sh
+COMPOSIT_TAG=${dcSTACK_VERSION}-postgres${postgresVersion}
 
 #build containers
 
 function base {
-    docker build --rm -t "devopscenter/base:${dcSTACK_VERSION}" .
+    docker build --rm --build-arg baseimageversion=${baseimageversion} -t "devopscenter/base:${COMPOSIT_TAG}" .
 }
 
 function db {
-    docker build --rm -t "devopscenter/db_base:${dcSTACK_VERSION}" db
-    docker build --rm -t "devopscenter/db_postgres:${dcSTACK_VERSION}" db/postgres
-#    docker build --rm -t "devopscenter/db_postgres-standby:${dcSTACK_VERSION}" db/postgres-standby
-#   docker build --rm -t "devopscenter/db_postgres-repmgr:${dcSTACK_VERSION}" db/postgres-repmgr
-#   docker build --rm -t "devopscenter/db_postgres-restore:${dcSTACK_VERSION}" db/postgres-restore
-    docker build --rm -t "devopscenter/db_redis:${dcSTACK_VERSION}" db/redis
-    docker build --rm -t "devopscenter/db_redis-standby:${dcSTACK_VERSION}" db/redis-standby
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/db_base:${COMPOSIT_TAG}" db
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/db_postgres:${COMPOSIT_TAG}" db/postgres
+#    docker build --rm -t "devopscenter/db_postgres-standby:${COMPOSIT_TAG}" db/postgres-standby
+#   docker build --rm -t "devopscenter/db_postgres-repmgr:${COMPOSIT_TAG}" db/postgres-repmgr
+#   docker build --rm -t "devopscenter/db_postgres-restore:${COMPOSIT_TAG}" db/postgres-restore
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/db_redis:${COMPOSIT_TAG}" db/redis
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/db_redis-standby:${COMPOSIT_TAG}" db/redis-standby
 }
 
 function misc {
-    docker build --rm -t "devopscenter/syslog:${dcSTACK_VERSION}" logging/. &> syslog.log &
-    docker build --rm -t "devopscenter/monitor_papertrail:${dcSTACK_VERSION}" monitor/papertrail &> papertrail.log &
-    docker build --rm -t "devopscenter/monitor_sentry:${dcSTACK_VERSION}" monitor/sentry &> sentry.log &
-    docker build --rm -t "devopscenter/monitor_nagios:${dcSTACK_VERSION}" monitor/nagios &> nagios.log &
+    docker build --rm --build-arg baseimageversion=${baseimageversion} -t "devopscenter/syslog:${COMPOSIT_TAG}" logging/. &> syslog.log &
+    docker build --rm --build-arg baseimageversion=${baseimageversion} -t "devopscenter/monitor_papertrail:${COMPOSIT_TAG}" monitor/papertrail &> papertrail.log &
+    docker build --rm -t "devopscenter/monitor_sentry:${COMPOSIT_TAG}" monitor/sentry &> sentry.log &
+    docker build --rm -t "devopscenter/monitor_nagios:${COMPOSIT_TAG}" monitor/nagios &> nagios.log &
 }
-# docker build --rm -t "devopscenter/loadbalancer_ssl-termination:${dcSTACK_VERSION}" loadbalancer/ssl-termination
-# docker build --rm -t "devopscenter/loadbalancer_haproxy:${dcSTACK_VERSION}" loadbalancer/haproxy
+# docker build --rm -t "devopscenter/loadbalancer_ssl-termination:${COMPOSIT_TAG}" loadbalancer/ssl-termination
+# docker build --rm -t "devopscenter/loadbalancer_haproxy:${COMPOSIT_TAG}" loadbalancer/haproxy
 
 function newrelic {
-    docker build --rm -t "devopscenter/monitor_newrelic:${dcSTACK_VERSION}" monitor/newrelic &
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/monitor_newrelic:${COMPOSIT_TAG}" monitor/newrelic &
 }
 
 function backups {
-    docker build --rm -t "devopscenter/db_postgres-backup:${dcSTACK_VERSION}" db/postgres-backup
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/db_postgres-backup:${COMPOSIT_TAG}" db/postgres-backup
 }
 
 function stack0 {
-    docker build --rm -t "devopscenter/000000.web:${dcSTACK_VERSION}" 000000-stack/web
-    docker build --rm -t "devopscenter/000000.web-debug:${dcSTACK_VERSION}" 000000-stack/web-debug
-    docker build --rm -t "devopscenter/000000.worker:${dcSTACK_VERSION}" 000000-stack/worker
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/000000.web:${COMPOSIT_TAG}" 000000-stack/web
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/000000.web-debug:${COMPOSIT_TAG}" 000000-stack/web-debug
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/000000.worker:${COMPOSIT_TAG}" 000000-stack/worker
 }
 
 function stack1 {
-    docker build --rm -t "devopscenter/0099ff.web:${dcSTACK_VERSION}" 0099ff-stack/web
-    docker build --rm -t "devopscenter/0099ff.web-debug:${dcSTACK_VERSION}" 0099ff-stack/web-debug
-    docker build --rm -t "devopscenter/0099ff.worker:${dcSTACK_VERSION}" 0099ff-stack/worker
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/0099ff.web:${COMPOSIT_TAG}" 0099ff-stack/web
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/0099ff.web-debug:${COMPOSIT_TAG}" 0099ff-stack/web-debug
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/0099ff.worker:${COMPOSIT_TAG}" 0099ff-stack/worker
 }
 
 function stack2 {
-    docker build --rm -t "devopscenter/66ccff.web:${dcSTACK_VERSION}" 66ccff-stack/web
-    docker build --rm -t "devopscenter/66ccff.worker:${dcSTACK_VERSION}" 66ccff-stack/worker
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/66ccff.web:${COMPOSIT_TAG}" 66ccff-stack/web
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/66ccff.worker:${COMPOSIT_TAG}" 66ccff-stack/worker
 }
 
 function stack3 {
-    docker build --rm -t "devopscenter/007acc.web:${dcSTACK_VERSION}" 007acc-stack/web
-    docker build --rm -t "devopscenter/007acc.worker:${dcSTACK_VERSION}" 007acc-stack/worker
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/007acc.web:${COMPOSIT_TAG}" 007acc-stack/web
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/007acc.worker:${COMPOSIT_TAG}" 007acc-stack/worker
 }
 
 function stack4 {
-    docker build --rm -t "devopscenter/9900af.web:${dcSTACK_VERSION}" 9900af-stack/web
-    docker build --rm -t "devopscenter/9900af.worker:${dcSTACK_VERSION}" 9900af-stack/worker
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/9900af.web:${COMPOSIT_TAG}" 9900af-stack/web
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/9900af.worker:${COMPOSIT_TAG}" 9900af-stack/worker
 }
 
 function stack5 {
-    docker build --rm -t "devopscenter/ab0000.web:${dcSTACK_VERSION}" ab0000-stack/web
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/ab0000.web:${COMPOSIT_TAG}" ab0000-stack/web
 }
 
 function stack6 {
-    docker build --rm -t "devopscenter/765ae2.web:${dcSTACK_VERSION}" 765ae2-stack/web
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/765ae2.web:${COMPOSIT_TAG}" 765ae2-stack/web
 }
 
 function web {
-    docker build --rm -t "devopscenter/python:${dcSTACK_VERSION}" python
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/python:${COMPOSIT_TAG}" python
     time newrelic &> newrelic.log &
     time backups &> backups.log &
-    docker build --rm -t "devopscenter/python-nginx:${dcSTACK_VERSION}" web/python-nginx
-    docker build --rm -t "devopscenter/python-nginx-pgpool:${dcSTACK_VERSION}" web/python-nginx-pgpool
-    docker build --rm -t "devopscenter/python-nginx-pgpool-redis:${dcSTACK_VERSION}" web/python-nginx-pgpool-redis
-#    docker build --rm -t "devopscenter/python-nginx-pgpool-libsodium:${dcSTACK_VERSION}" web/python-nginx-pgpool-libsodium
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/python-nginx:${COMPOSIT_TAG}" web/python-nginx
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/python-nginx-pgpool:${COMPOSIT_TAG}" web/python-nginx-pgpool
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}" web/python-nginx-pgpool-redis
+#    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/python-nginx-pgpool-libsodium:${COMPOSIT_TAG}" web/python-nginx-pgpool-libsodium
     echo "built common containers"
 }
 
 function web-all {
-    docker build --rm -t "devopscenter/python:${dcSTACK_VERSION}" python
-    time newrelic &> newrelic.log &
-    time backups &> backups.log &
-    docker build --rm -t "devopscenter/python-nginx:${dcSTACK_VERSION}" web/python-nginx
-    docker build --rm -t "devopscenter/python-nginx-pgpool:${dcSTACK_VERSION}" web/python-nginx-pgpool
-    docker build --rm -t "devopscenter/python-nginx-pgpool-redis:${dcSTACK_VERSION}" web/python-nginx-pgpool-redis
-#    docker build --rm -t "devopscenter/python-nginx-pgpool-libsodium:${dcSTACK_VERSION}" web/python-nginx-pgpool-libsodium
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/python:${COMPOSIT_TAG}" python
+    newrelic &> newrelic.log &
+    backups &> backups.log &
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/python-nginx:${COMPOSIT_TAG}" web/python-nginx
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/python-nginx-pgpool:${COMPOSIT_TAG}" web/python-nginx-pgpool
+    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} --build-arg POSTGRES_VERSION=${postgresVersion} -t "devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}" web/python-nginx-pgpool-redis
+#    docker build --rm --build-arg COMPOSIT_TAG=${COMPOSIT_TAG} -t "devopscenter/python-nginx-pgpool-libsodium:${COMPOSIT_TAG}" web/python-nginx-pgpool-libsodium
     echo "built common containers"
 
 
     rm -rf stack0.log
-    time stack0 &> stack0.log &
+    stack0 &> stack0.log
     rm -rf stack1.log
-    time stack1 &> stack1.log &
+    stack1 &> stack1.log
     rm -rf stack2.log
-    time stack2 &> stack2.log &
+    stack2 &> stack2.log
     rm -rf stack3.log
-    time stack3 &> stack3.log &
+    stack3 &> stack3.log
     rm -rf stack4.log
-    time stack4 &> stack4.log &
+    stack4 &> stack4.log
     rm -rf stack5.log
-    time stack5 &> stack5.log &
+    stack5 &> stack5.log
     rm -rf stack6.log
-    time stack6 &> stack5.log &
+    stack6 &> stack5.log
 }
 
 if [[ $# -gt 0 ]]; then
     ${1} > ${1}.log
 else
-    base > base.log 
-    time misc &> misc.log &
-    time web-all &> web.log &
-    time db &> db.log &
+    # ORIGINAL flow
+    #base > base.log
+    #time misc &> misc.log &
+    #time web-all &> web.log &
+    #time db &> db.log &
+    postgresVersion=9.4
+    COMPOSIT_TAG=${dcSTACK_VERSION}-postgres${postgresVersion}
+    echo  ${COMPOSIT_TAG}
+    base > base9.4.log
+    misc &> misc9.4.log &
+    web-all &> web9.4.log
+    db &> db9.4.log
+    postgresVersion=9.6
+    COMPOSIT_TAG=${dcSTACK_VERSION}-postgres${postgresVersion}
+    echo  ${COMPOSIT_TAG}
+    base > base9.6.log
+    misc &> misc9.6.log &
+    web-all &> web9.6.log
+    db &> db9.6.log
 fi

--- a/buildtools/jenkins/Dockerfile
+++ b/buildtools/jenkins/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/base:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/base:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ADD jenkins.sh /installs/jenkins-install.sh

--- a/buildtools/jenkins/Dockerfile
+++ b/buildtools/jenkins/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/base:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/base:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ADD jenkins.sh /installs/jenkins-install.sh

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/base:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/base:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 # Install pip

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/base:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/base:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 # Install pip

--- a/db/postgres-backup/Dockerfile
+++ b/db/postgres-backup/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 ARG POSTGRES_VERSION

--- a/db/postgres-backup/Dockerfile
+++ b/db/postgres-backup/Dockerfile
@@ -19,7 +19,8 @@
 FROM devopscenter/python:dcSTACK_VERSION
 MAINTAINER josh < josh [at] devops {dot} center>
 
-ENV POSTGRES_VERSION 9.6
+ARG POSTGRES_VERSION
+ENV POSTGRES_VERSION ${POSTGRES_VERSION}
 
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
@@ -32,7 +33,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -sc)-pgdg m
 
 RUN sudo apt-fast update
 
-RUN sudo apt-fast -y -q install postgresql-client-$POSTGRES_VERSION libpq5 libpq-dev
+RUN sudo apt-fast -y -q install postgresql-client-${POSTGRES_VERSION} libpq5 libpq-dev
 
 RUn sudo pip install s3cmd==1.5.2
 

--- a/db/postgres-backup/Dockerfile
+++ b/db/postgres-backup/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 ARG POSTGRES_VERSION

--- a/db/postgres-repmgr/Dockerfile
+++ b/db/postgres-repmgr/Dockerfile
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ARG COMPOSIT_TAG
-FROM devopscenter/db_postgres:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/db_postgres:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 USER root

--- a/db/postgres-repmgr/Dockerfile
+++ b/db/postgres-repmgr/Dockerfile
@@ -15,7 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM devopscenter/db_postgres:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/db_postgres:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 USER root

--- a/db/postgres-restore/Dockerfile
+++ b/db/postgres-restore/Dockerfile
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ARG COMPOSIT_TAG
-FROM devopscenter/db_postgres-repmgr:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/db_postgres-repmgr:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 USER root

--- a/db/postgres-restore/Dockerfile
+++ b/db/postgres-restore/Dockerfile
@@ -15,7 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM devopscenter/db_postgres-repmgr:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/db_postgres-repmgr:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 USER root

--- a/db/postgres-standby/Dockerfile
+++ b/db/postgres-standby/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/db_postgres:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/db_postgres:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 RUN echo "autostart=false" >> /etc/supervisor/conf.d/postgres.conf

--- a/db/postgres-standby/Dockerfile
+++ b/db/postgres-standby/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/db_postgres:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/db_postgres:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 RUN echo "autostart=false" >> /etc/supervisor/conf.d/postgres.conf

--- a/db/postgres/Dockerfile
+++ b/db/postgres/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/db_base:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/db_base:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ARG POSTGRES_VERSION

--- a/db/postgres/Dockerfile
+++ b/db/postgres/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/db_base:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/db_base:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ARG POSTGRES_VERSION

--- a/db/postgres/Dockerfile
+++ b/db/postgres/Dockerfile
@@ -19,7 +19,8 @@
 FROM devopscenter/db_base:dcSTACK_VERSION
 MAINTAINER bob < bob [at] devops {dot} center>
 
-ENV POSTGRES_VERSION 9.6
+ARG POSTGRES_VERSION
+ENV POSTGRES_VERSION ${POSTGRES_VERSION}
 
 WORKDIR /root/installs
 
@@ -31,7 +32,7 @@ ADD hstore.sh /root/installs/hstore.sh
 ADD postgresenv.sh /root/installs/postgresenv.sh
 ADD supervisorconfig.sh /root/installs/supervisorconfig.sh
 
-RUN ./postgres.sh $POSTGRES_VERSION && \
+RUN ./postgres.sh ${POSTGRES_VERSION} && \
     cp conf/postgresql.conf.local /media/data/postgres/db/pgdata/postgresql.conf
 
 # Run supervisor in this container, in foreground mode

--- a/db/postgres/postgresenv.sh
+++ b/db/postgres/postgresenv.sh
@@ -42,7 +42,7 @@ set -o verbose
 PGVERSION=$1
 
 # default postgres version to install
-POSTGRES_VERSION=9.6
+POSTGRES_VERSION=9.4
 
 # If the version number is specified, then override the default version number.
 if [ -n "$PGVERSION" ]; then

--- a/db/postgres/postgresenv.sh
+++ b/db/postgres/postgresenv.sh
@@ -42,7 +42,7 @@ set -o verbose
 PGVERSION=$1
 
 # default postgres version to install
-POSTGRES_VERSION=9.4
+POSTGRES_VERSION=9.6
 
 # If the version number is specified, then override the default version number.
 if [ -n "$PGVERSION" ]; then

--- a/db/redis-standby/Dockerfile
+++ b/db/redis-standby/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/db_redis:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/db_redis:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 RUN echo "slaveof redismaster-1 6379" >> /etc/redis/redis.conf

--- a/db/redis-standby/Dockerfile
+++ b/db/redis-standby/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/db_redis:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/db_redis:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 RUN echo "slaveof redismaster-1 6379" >> /etc/redis/redis.conf

--- a/db/redis/Dockerfile
+++ b/db/redis/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-
-FROM devopscenter/db_base:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/db_base:${COMPOSIT_TAG}
 
 MAINTAINER josh < josh [at] devops {dot} center>
 

--- a/db/redis/Dockerfile
+++ b/db/redis/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/db_base:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/db_base:${COMPOSITE_TAG}
 
 MAINTAINER josh < josh [at] devops {dot} center>
 

--- a/djangoreferenceimplementation-stack/web/Dockerfile
+++ b/djangoreferenceimplementation-stack/web/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python-nginx-pgpool-redis:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 ADD wheelhouse /wheelhouse

--- a/djangoreferenceimplementation-stack/web/Dockerfile
+++ b/djangoreferenceimplementation-stack/web/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python-nginx-pgpool-redis:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python-nginx-pgpool-redis:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 ADD wheelhouse /wheelhouse

--- a/djangoreferenceimplementation-stack/worker/Dockerfile
+++ b/djangoreferenceimplementation-stack/worker/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/djangoreferenceimplementation.web:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/djangoreferenceimplementation.web:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 RUN rm -rf /etc/supervisor/conf.d/nginx.conf && rm -rf /etc/supervisor/conf.d/uwsgi.conf

--- a/djangoreferenceimplementation-stack/worker/Dockerfile
+++ b/djangoreferenceimplementation-stack/worker/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/djangoreferenceimplementation.web:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/djangoreferenceimplementation.web:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 RUN rm -rf /etc/supervisor/conf.d/nginx.conf && rm -rf /etc/supervisor/conf.d/uwsgi.conf

--- a/logging/Dockerfile
+++ b/logging/Dockerfile
@@ -1,4 +1,5 @@
-FROM baseimageversion 
+ARG baseimageversion
+FROM ${baseimageversion}
 MAINTAINER Bob Lozano <bob@devops.center>
 
 RUN apt-get update && \

--- a/monitor/nagios/Dockerfile
+++ b/monitor/nagios/Dockerfile
@@ -29,7 +29,8 @@ apt-get -qq -y install apt-fast
 
 RUN apt-get install sudo
 
-ENV POSTGRES_VERSION 9.6
+ARG POSTGRES_VERSION
+ENV POSTGRES_VERSION ${POSTGRES_VERSION}
 
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
@@ -42,7 +43,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -sc)-pgdg m
 
 RUN sudo apt-fast -qq update
 
-RUN sudo apt-fast -y -qq install postgresql-client-$POSTGRES_VERSION libpq5 libpq-dev
+RUN sudo apt-fast -y -qq install postgresql-client-${POSTGRES_VERSION} libpq5 libpq-dev
 
 #RUN sudo apt-fast -y install supervisor
 

--- a/monitor/newrelic/Dockerfile
+++ b/monitor/newrelic/Dockerfile
@@ -19,7 +19,8 @@
 FROM devopscenter/python:dcSTACK_VERSION
 MAINTAINER josh < josh [at] devops {dot} center>
 
-ENV POSTGRES_VERSION 9.6
+ARG POSTGRES_VERSION
+ENV POSTGRES_VERSION ${POSTGRES_VERSION}
 
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
@@ -32,7 +33,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -sc)-pgdg m
 
 RUN sudo apt-fast update
 
-RUN sudo apt-fast -y -q install postgresql-client-$POSTGRES_VERSION libpq5 libpq-dev
+RUN sudo apt-fast -y -q install postgresql-client-${POSTGRES_VERSION} libpq5 libpq-dev
 
 RUN pip install git+https://github.com/josh-devops-center/newrelic-plugin-agent@5f1ec79094815486d26bc66a55b5ff1d1e97b6c7#egg=newrelic-plugin-agent
 RUN pip install newrelic-plugin-agent[postgresql]

--- a/monitor/newrelic/Dockerfile
+++ b/monitor/newrelic/Dockerfile
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-FROM devopscenter/python:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 ARG POSTGRES_VERSION

--- a/monitor/newrelic/Dockerfile
+++ b/monitor/newrelic/Dockerfile
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ARG COMPOSIT_TAG
-FROM devopscenter/python:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 ARG POSTGRES_VERSION

--- a/monitor/papertrail/Dockerfile
+++ b/monitor/papertrail/Dockerfile
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
-FROM baseimageversion
+ARG baseimageversion
+FROM ${baseimageversion}
 MAINTAINER josh < josh [at] devops {dot} center>
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 

--- a/push.sh
+++ b/push.sh
@@ -43,67 +43,67 @@ source VERSION
 echo "Version=${dcSTACK_VERSION}"
 
 function base {
-    docker push  "devopscenter/base:${dcSTACK_VERSION}"
+    docker push  "devopscenter/base:${COMPOSITE_TAG}"
 }
 
 function db {
-    docker push  "devopscenter/db_base:${dcSTACK_VERSION}"
-    docker push  "devopscenter/db_postgres:${dcSTACK_VERSION}"  
-#    docker push  "devopscenter/db_postgres-standby:${dcSTACK_VERSION}"
-#    docker push  "devopscenter/db_postgres-repmgr:${dcSTACK_VERSION}"
-#   docker push  "devopscenter/db_postgres-restore:${dcSTACK_VERSION}"
-    docker push  "devopscenter/db_redis:${dcSTACK_VERSION}"
-    docker push  "devopscenter/db_redis-standby:${dcSTACK_VERSION}"
+    docker push  "devopscenter/db_base:${COMPOSITE_TAG}"
+    docker push  "devopscenter/db_postgres:${COMPOSITE_TAG}"  
+#    docker push  "devopscenter/db_postgres-standby:${COMPOSITE_TAG}"
+#    docker push  "devopscenter/db_postgres-repmgr:${COMPOSITE_TAG}"
+#   docker push  "devopscenter/db_postgres-restore:${COMPOSITE_TAG}"
+    docker push  "devopscenter/db_redis:${COMPOSITE_TAG}"
+    docker push  "devopscenter/db_redis-standby:${COMPOSITE_TAG}"
 }
 
 function misc {
-    docker push  "devopscenter/syslog:${dcSTACK_VERSION}"
-    docker push  "devopscenter/monitor_papertrail:${dcSTACK_VERSION}"
-    docker push  "devopscenter/monitor_sentry:${dcSTACK_VERSION}"
-#    docker push  "devopscenter/monitor_nagios:${dcSTACK_VERSION}"
-    docker push  "devopscenter/monitor_newrelic:${dcSTACK_VERSION}" 
+    docker push  "devopscenter/syslog:${COMPOSITE_TAG}"
+    docker push  "devopscenter/monitor_papertrail:${COMPOSITE_TAG}"
+    docker push  "devopscenter/monitor_sentry:${COMPOSITE_TAG}"
+#    docker push  "devopscenter/monitor_nagios:${COMPOSITE_TAG}"
+    docker push  "devopscenter/monitor_newrelic:${COMPOSITE_TAG}" 
 }
 
 function stack0 {
-    docker push  "devopscenter/000000.web:${dcSTACK_VERSION}" 
-    docker push  "devopscenter/000000.web-debug:${dcSTACK_VERSION}"
-    docker push  "devopscenter/000000.worker:${dcSTACK_VERSION}" 
+    docker push  "devopscenter/000000.web:${COMPOSITE_TAG}" 
+    docker push  "devopscenter/000000.web-debug:${COMPOSITE_TAG}"
+    docker push  "devopscenter/000000.worker:${COMPOSITE_TAG}" 
 }
 
 function stack1 {
-    docker push  "devopscenter/0099ff.web:${dcSTACK_VERSION}" 
-    docker push  "devopscenter/0099ff.web-debug:${dcSTACK_VERSION}"
-    docker push  "devopscenter/0099ff.worker:${dcSTACK_VERSION}" 
+    docker push  "devopscenter/0099ff.web:${COMPOSITE_TAG}" 
+    docker push  "devopscenter/0099ff.web-debug:${COMPOSITE_TAG}"
+    docker push  "devopscenter/0099ff.worker:${COMPOSITE_TAG}" 
 }
 
 function stack2 {
-    docker push  "devopscenter/66ccff.web:${dcSTACK_VERSION}" 
-    docker push  "devopscenter/66ccff.worker:${dcSTACK_VERSION}" 
+    docker push  "devopscenter/66ccff.web:${COMPOSITE_TAG}" 
+    docker push  "devopscenter/66ccff.worker:${COMPOSITE_TAG}" 
 }
 
 function stack3 {
-    docker push  "devopscenter/007acc.web:${dcSTACK_VERSION}"
-    docker push  "devopscenter/007acc.worker:${dcSTACK_VERSION}"
+    docker push  "devopscenter/007acc.web:${COMPOSITE_TAG}"
+    docker push  "devopscenter/007acc.worker:${COMPOSITE_TAG}"
 }
 
 function stack4 {
-    docker push  "devopscenter/9900af.web:${dcSTACK_VERSION}"
-    docker push  "devopscenter/9900af.worker:${dcSTACK_VERSION}"
+    docker push  "devopscenter/9900af.web:${COMPOSITE_TAG}"
+    docker push  "devopscenter/9900af.worker:${COMPOSITE_TAG}"
 }
 
 function stack5 {
-    docker push  "devopscenter/ab0000.web:${dcSTACK_VERSION}"
+    docker push  "devopscenter/ab0000.web:${COMPOSITE_TAG}"
 }
 
 function stack6 {
-    docker push  "devopscenter/765ae2.web:${dcSTACK_VERSION}"
+    docker push  "devopscenter/765ae2.web:${COMPOSITE_TAG}"
 }
 
 function web {
-    docker push  "devopscenter/python:${dcSTACK_VERSION}"
-    docker push  "devopscenter/python-nginx:${dcSTACK_VERSION}"
-    docker push  "devopscenter/python-nginx-pgpool:${dcSTACK_VERSION}"
-    docker push  "devopscenter/python-nginx-pgpool-redis:${dcSTACK_VERSION}"
+    docker push  "devopscenter/python:${COMPOSITE_TAG}"
+    docker push  "devopscenter/python-nginx:${COMPOSITE_TAG}"
+    docker push  "devopscenter/python-nginx-pgpool:${COMPOSITE_TAG}"
+    docker push  "devopscenter/python-nginx-pgpool-redis:${COMPOSITE_TAG}"
     rm -rf stack0push.log
     time stack0 &> stack0push.log &
     rm -rf stack1push.log
@@ -119,6 +119,19 @@ function web {
     rm -rf stack6push.log
     time stack6 &> stack6push.log &
 }
+
+postgresVersion=9.4
+COMPOSITE_TAG=${dcSTACK_VERSION}-postgres${postgresVersion}
+echo  ${COMPOSITE_TAG}
+
+base
+misc
+web
+db
+
+postgresVersion=9.6
+COMPOSITE_TAG=${dcSTACK_VERSION}-postgres${postgresVersion}
+echo  ${COMPOSITE_TAG}
 
 base
 misc

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/base:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/base:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/base:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/base:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 

--- a/web/php-nginx/Dockerfile
+++ b/web/php-nginx/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/php:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/php:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 EXPOSE 80 8000 443

--- a/web/php-nginx/Dockerfile
+++ b/web/php-nginx/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/php:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/php:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 EXPOSE 80 8000 443

--- a/web/python-nginx-pgpool-libsodium/Dockerfile
+++ b/web/python-nginx-pgpool-libsodium/Dockerfile
@@ -1,4 +1,5 @@
-FROM devopscenter/python-nginx-pgpool:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python-nginx-pgpool:${COMPOSIT_TAG}
 
 RUN mkdir /repos
 WORKDIR /repos

--- a/web/python-nginx-pgpool-libsodium/Dockerfile
+++ b/web/python-nginx-pgpool-libsodium/Dockerfile
@@ -1,5 +1,5 @@
-ARG COMPOSIT_TAG
-FROM devopscenter/python-nginx-pgpool:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python-nginx-pgpool:${COMPOSITE_TAG}
 
 RUN mkdir /repos
 WORKDIR /repos

--- a/web/python-nginx-pgpool-redis/Dockerfile
+++ b/web/python-nginx-pgpool-redis/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python-nginx-pgpool:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python-nginx-pgpool:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 ADD redis-client-install.sh /installs/redis-client-install.sh

--- a/web/python-nginx-pgpool-redis/Dockerfile
+++ b/web/python-nginx-pgpool-redis/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python-nginx-pgpool:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python-nginx-pgpool:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 ADD redis-client-install.sh /installs/redis-client-install.sh

--- a/web/python-nginx-pgpool/Dockerfile
+++ b/web/python-nginx-pgpool/Dockerfile
@@ -19,7 +19,8 @@
 FROM devopscenter/python-nginx:dcSTACK_VERSION
 MAINTAINER bob < bob [at] devops {dot} center>
 
-ENV POSTGRES_VERSION 9.6
+ARG POSTGRES_VERSION
+ENV POSTGRES_VERSION ${POSTGRES_VERSION}
 
 ADD pgpool /installs/pgpool
 ADD pgpoolenv.sh /installs/pgpoolenv.sh
@@ -30,6 +31,6 @@ ADD run_pgpool.sh /installs/run_pgpool.sh
 ADD pgpool.sh /installs/pgpool.sh
 
 WORKDIR /installs
-RUN ./pgpool.sh $POSTGRES_VERSION
+RUN ./pgpool.sh ${POSTGRES_VERSION}
 
 CMD /bin/bash -c "rm -rf /var/run/pgpool/pgpool.pid && rm -rf /var/run/postgresql/.s.* && /usr/bin/supervisord && tail -f /dev/null"

--- a/web/python-nginx-pgpool/Dockerfile
+++ b/web/python-nginx-pgpool/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python-nginx:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python-nginx:${COMPOSIT_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ARG POSTGRES_VERSION

--- a/web/python-nginx-pgpool/Dockerfile
+++ b/web/python-nginx-pgpool/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python-nginx:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python-nginx:${COMPOSITE_TAG}
 MAINTAINER bob < bob [at] devops {dot} center>
 
 ARG POSTGRES_VERSION

--- a/web/python-nginx/Dockerfile
+++ b/web/python-nginx/Dockerfile
@@ -16,8 +16,8 @@
 # limitations under the License.
 #
 
-ARG COMPOSIT_TAG
-FROM devopscenter/python:${COMPOSIT_TAG}
+ARG COMPOSITE_TAG
+FROM devopscenter/python:${COMPOSITE_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 EXPOSE 80 8000 443

--- a/web/python-nginx/Dockerfile
+++ b/web/python-nginx/Dockerfile
@@ -16,7 +16,8 @@
 # limitations under the License.
 #
 
-FROM devopscenter/python:dcSTACK_VERSION
+ARG COMPOSIT_TAG
+FROM devopscenter/python:${COMPOSIT_TAG}
 MAINTAINER josh < josh [at] devops {dot} center>
 
 EXPOSE 80 8000 443


### PR DESCRIPTION
This set of changes reflects the use of passing build arguments to each of the docker files such that there is no need to do a manual sed to change the files to do a build and then have to do a subsequent reset before committing.  Also, using the same facility to pass build args, change the postgres version on a build by passing in the version number and then setting an environment variable.  The is accomplished through the build.sh script which also has the ability to build both a set of docker images for postgres 9.4 and 9.6, tagging each with an appropriate composite tag.